### PR TITLE
Use files instead of npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,0 @@
-ios/
-android/
-yarn.lock
-.flowconfig
-.buckconfig
-.gitattributes
-.watchmanconfig

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "version": "1.2.3",
   "description": "Components and API for Electrode Native Navigation",
   "main": "src/index.js",
+  "files": [
+    "src/"
+  ],
   "scripts": {
     "docs": "rm -rf docs/ && jsdoc -c jsdoc.js",
     "docs:private": "rm -rf docs-private/ && jsdoc -c jsdoc.js -p",


### PR DESCRIPTION
Commit moved over from #7

It's better to specifically whitelist files to _include_ in the published artifact instead of blacklisting files (which might accidentally include files that are not needed).

Below are the tarball details before and after:

```
npm notice package size:  251.7 kB
npm notice unpacked size: 980.7 kB
npm notice shasum:        a29e8943db7a3a09f68a358be2581d7ad246e410
npm notice integrity:     sha512-RpcgZtKJI06Tx[...]eerFFwHBpEjpA==
npm notice total files:   49
```

```
npm notice package size:  9.3 kB
npm notice unpacked size: 33.2 kB
npm notice shasum:        9415cfa2f8f1572133bafb26fec2fa461d7b1493
npm notice integrity:     sha512-minhJA3LTY8iq[...]clZeaen/yx5mQ==
npm notice total files:   7
```
