### PR TITLE
Remove direct dependency to `en-navigation-api`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "homepage": "https://github.com/electrode-io/ern-navigation#readme",
   "dependencies": {
-    "ernnavigation-api": "^1.1.0",
     "ernnavigation-api-impl-native": "^1.2.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
This has to be transitive dependency inside the `ernnavigation-api-impl-native`.

AN update to the API should always be controlled by the implementation to avoid the introduction of any breaking change.
https://github.com/electrode-io/ernnavigation-api-impl-native/blob/master/package.json#L6