### PR TITLE
Deploy website/docs automatically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,5 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
-        with:
-          node-version: 12
       - run: yarn
       - run: yarn lint
-      - name: Check docs
-        run: yarn docs && \[ -z "$(git status --porcelain)" \] || (echo "Docs are out-of-sync. Please run 'yarn docs' using Node.js 12 or later, and include doc updates in the same commit that changed the code." && exit 1)

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,19 @@
+name: gh-pages
+on:
+  push:
+    branches:
+      - master
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - run: yarn
+      - run: yarn docs
+      - uses: peaceiris/actions-gh-pages@v3
+        with:
+          commit_message: Deploy
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -55,4 +55,5 @@ buck-out/
 # Bundle artifact
 *.jsbundle
 
-docs-private/
+# Generated JSDoc website
+public/

--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ Detailed API documentation is available on our website:
 
 [https://www.electrode.io/ern-navigation][7]
 
+Updates to the documentation will be deployed to `gh-pages` automatically with
+every merge to `master`. The documentation can also be generated locally by
+running `yarn docs`. Open `public/index.html` to preview the website. Use
+`yarn docs -p` to include private symbols as well.
+
 ## Example
 
 First, let's create some components to act as the app's different screens.

--- a/jsdoc.js
+++ b/jsdoc.js
@@ -14,7 +14,7 @@ module.exports = {
     include: ['src'],
   },
   opts: {
-    destination: 'docs',
+    destination: 'public',
     readme: 'README.md',
     recurse: true,
     template: 'node_modules/foodoc/template',

--- a/jsdoc.js
+++ b/jsdoc.js
@@ -8,6 +8,7 @@ module.exports = {
     systemLogo: 'ern_logo_80.png',
     systemColor: '#183055',
     includeDate: false,
+    collapseSymbols: false,
   },
   source: {
     include: ['src'],

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "src/"
   ],
   "scripts": {
-    "docs": "rm -rf docs/ && jsdoc -c jsdoc.js",
-    "docs:private": "rm -rf docs-private/ && jsdoc -c jsdoc.js -p",
+    "docs": "jsdoc -c jsdoc.js",
     "lint": "eslint ."
   },
   "repository": {


### PR DESCRIPTION
This adds a new GitHub Actions workflow **gh-pages.yml** which automatically deploys the updated docs/website to the `gh-pages` branch on every merge to `master`.

Also expand symbols by default (as discussed in the meeting this morning).