### PR TITLE
update ern-navigation-api and api-impl-native to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   },
   "homepage": "https://github.com/electrode-io/ern-navigation#readme",
   "dependencies": {
-    "ernnavigation-api": "^1.2.5",
-    "ernnavigation-api-impl-native": "^1.3.18"
+    "ernnavigation-api": "^2.0.0",
+    "ernnavigation-api-impl-native": "^2.0.0"
   },
   "peerDependencies": {
     "react": ">=15.0.0",


### PR DESCRIPTION
- update ern-navigation-api and  ern-navigation-api-impl-native to 2.0.0.

[DO-NOT-MERGE] Have to generate the yarn.lock once above packages are published.